### PR TITLE
doc: Update peer command help to add package file argument

### DIFF
--- a/docs/source/commands/peerlifecycle.md
+++ b/docs/source/commands/peerlifecycle.md
@@ -116,7 +116,7 @@ Global Flags:
 Install a chaincode on a peer.
 
 Usage:
-  peer lifecycle chaincode install [flags]
+  peer lifecycle chaincode install [packageFiles] [flags]
 
 Flags:
       --connectionProfile string       The fully qualified path to the connection profile that provides the necessary connection information for the network. Note: currently only supported for providing peer connection information


### PR DESCRIPTION

#### Type of change

- Documentation update

#### Description

The help information for this command is missing the package file parameter which should come after the word "install"

#### Additional details

Fix help information "peer lifecycle chaincode install  [flags]" with "peer lifecycle chaincode install [packageFiles] [flags]"


